### PR TITLE
Add full test coverage and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test -- --coverage

--- a/src/__tests__/clients.test.ts
+++ b/src/__tests__/clients.test.ts
@@ -1,0 +1,130 @@
+import axios from 'axios';
+import { ChatGpt } from '../clients/openai';
+import { Gemini } from '../clients/gemini';
+import { Claude } from '../clients/claude';
+import { ClientError } from '../error';
+import { ClientConfig } from '../types';
+
+jest.mock('axios');
+
+const postMock = jest.fn();
+(axios.create as jest.Mock).mockReturnValue({ post: postMock });
+
+const baseConfig: ClientConfig = { timeout: 1, retries: 1 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (axios.create as jest.Mock).mockReturnValue({ post: postMock });
+});
+
+describe.each([
+  ['ChatGpt', ChatGpt],
+  ['Gemini', Gemini],
+  ['Claude', Claude],
+])('%s client', (_name, ClientCtor) => {
+  it('sends prompt successfully', async () => {
+    postMock.mockResolvedValueOnce(
+      ClientCtor === ChatGpt
+        ? { data: { choices: [{ message: { content: 'ok' } }] } }
+        : ClientCtor === Gemini
+        ? { data: { candidates: [{ content: { parts: [{ text: 'ok' }] } }] } }
+        : { data: { content: [{ text: 'ok' }] } }
+    );
+    const client = new ClientCtor('key', 'model', baseConfig);
+    const result = await client.sendPrompt('hi');
+    expect(result).toBe('ok');
+  });
+
+  it('sends prompt with temperature', async () => {
+    postMock.mockResolvedValueOnce(
+      ClientCtor === ChatGpt
+        ? { data: { choices: [{ message: { content: 'ok' } }] } }
+        : ClientCtor === Gemini
+        ? { data: { candidates: [{ content: { parts: [{ text: 'ok' }] } }] } }
+        : { data: { content: [{ text: 'ok' }] } }
+    );
+    const cfg: ClientConfig = { timeout: 1, retries: 0, temperature: 0.5 };
+    const client = new ClientCtor('key', 'model', cfg);
+    const result = await client.sendPrompt('hi');
+    expect(result).toBe('ok');
+  });
+
+  it('throws when response missing', async () => {
+    postMock.mockResolvedValueOnce(
+      ClientCtor === ChatGpt
+        ? { data: { choices: [{ message: {} }] } }
+        : ClientCtor === Gemini
+        ? { data: { candidates: [{ content: { parts: [{}] } }] } }
+        : { data: { content: [{}] } }
+    );
+    const client = new ClientCtor('key', 'model', baseConfig);
+    await expect(client.sendPrompt('hi')).rejects.toBeInstanceOf(ClientError);
+  });
+
+  it('retries and throws ClientError', async () => {
+    (axios.isAxiosError as unknown as jest.Mock).mockReturnValue(false);
+    postMock.mockRejectedValue(new Error('fail'));
+    const client = new ClientCtor('key', 'model', baseConfig);
+    (client as any).delay = jest.fn(() => Promise.resolve());
+    await expect(client.sendPrompt('hi')).rejects.toBeInstanceOf(ClientError);
+    expect((client as any).delay).toHaveBeenCalled();
+  });
+
+  it('delay helper resolves', async () => {
+    const client = new ClientCtor('key', 'model', baseConfig);
+    await expect((client as any).delay(0)).resolves.toBeUndefined();
+  });
+
+  describe('handleError branches', () => {
+    let client: any;
+    beforeEach(() => {
+      client = new ClientCtor('key', 'model', baseConfig);
+    });
+
+    function call(err: any) {
+      (axios.isAxiosError as unknown as jest.Mock).mockReturnValue(true);
+      return client.handleError(err);
+    }
+
+    it('timeout', () => {
+      const err = { code: 'ETIMEDOUT' };
+      expect(call(err).message).toBe('Network error: Request timeout');
+    });
+
+    it('connection failed', () => {
+      const err = { code: 'ECONNREFUSED' };
+      expect(call(err).message).toBe('Network error: Connection failed');
+    });
+
+    it('status 401', () => {
+      const err = { code: 'ERR', response: { status: 401 }, message: 'm' };
+      expect(call(err).message).toBe('Authentication error: Invalid API key');
+    });
+
+    it('status 429', () => {
+      const err = { code: 'ERR', response: { status: 429 }, message: 'm' };
+      expect(call(err).message).toBe('Api error: Rate limit exceeded');
+    });
+
+    it('status other', () => {
+      const err = { code: 'ERR', response: { status: 500 }, message: 'oops' };
+      expect(call(err).message).toBe('Api error: HTTP 500: oops');
+    });
+
+    it('network message', () => {
+      const err = { code: 'ERR', message: 'bad' };
+      expect(call(err).message).toBe('Network error: bad');
+    });
+
+    it('parse error', () => {
+      (axios.isAxiosError as unknown as jest.Mock).mockReturnValue(false);
+      const error = new Error('json');
+      expect(client.handleError(error).message).toBe('Parse error: JSON parsing failed: json');
+    });
+
+    it('unknown', () => {
+      (axios.isAxiosError as unknown as jest.Mock).mockReturnValue(false);
+      expect(client.handleError(123).message).toBe('Network error: Unknown error occurred');
+    });
+  });
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -45,6 +45,26 @@ describe('ChatDelta', () => {
       expect(client.model()).toBe('gpt-4');
     });
 
+    it('should create client with default config', () => {
+      const client = createClient('openai', 'test-key', 'gpt-4');
+      expect(client.name()).toBe('ChatGPT');
+    });
+
+    it('should create GPT client via alias', () => {
+      const client = createClient('gpt', 'test-key', 'gpt-4', config);
+      expect(client.name()).toBe('ChatGPT');
+    });
+
+    it('should create ChatGPT client via alias', () => {
+      const client = createClient('chatgpt', 'test-key', 'gpt-4', config);
+      expect(client.name()).toBe('ChatGPT');
+    });
+
+    it('should create Google client via alias', () => {
+      const client = createClient('google', 'test-key', 'gemini-pro', config);
+      expect(client.name()).toBe('Gemini');
+    });
+
     it('should create Claude client', () => {
       const client = createClient('claude', 'test-key', 'claude-3', config);
       expect(client.name()).toBe('Claude');
@@ -55,6 +75,11 @@ describe('ChatDelta', () => {
       const client = createClient('gemini', 'test-key', 'gemini-pro', config);
       expect(client.name()).toBe('Gemini');
       expect(client.model()).toBe('gemini-pro');
+    });
+
+    it('should create Anthropic client via alias', () => {
+      const client = createClient('anthropic', 'test-key', 'claude-3', config);
+      expect(client.name()).toBe('Claude');
     });
 
     it('should throw error for unknown provider', () => {
@@ -91,6 +116,24 @@ describe('ChatDelta', () => {
       expect(results).toHaveLength(2);
       expect(results[0].result).toBe('response1');
       expect(results[1].result).toBeInstanceOf(ClientError);
+    });
+
+    it('should wrap non ClientError exceptions', async () => {
+      const bad: AiClient = {
+        async sendPrompt() {
+          throw new Error('boom');
+        },
+        name() {
+          return 'bad';
+        },
+        model() {
+          return 'm';
+        },
+      };
+
+      const results = await executeParallel([bad], 'x');
+      expect(results[0].result).toBeInstanceOf(ClientError);
+      expect((results[0].result as ClientError).message).toBe('Network error: Unknown error');
     });
   });
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for CI
- extend unit tests with client coverage
- cover additional createClient aliases and error cases

## Testing
- `npx jest --coverage --silent`


------
https://chatgpt.com/codex/tasks/task_e_68740a17f6d0832581996aa7653a83fe